### PR TITLE
make reflow first line configurable

### DIFF
--- a/agito.py
+++ b/agito.py
@@ -587,8 +587,13 @@ def reflow_text(path, entry, message):
 	  Reflowed commit message text.
 	"""
 	result = []
+	lines = message.split("\n")
 
-	for line in message.split("\n"):
+	# reflow of first line may be not wanted
+	if not REFLOW_FIRST_LINE:
+		result.append(lines.pop(0))
+
+	for line in lines:
 		result.append(reflow_line(line))
 
 	return "\n".join(result)
@@ -1025,6 +1030,10 @@ assert ("GIT_REPO" in config), \
 # Set up merge_callbacks and add svn:mergeinfo handler.
 merge_callbacks = config.get('MERGE_CALLBACKS', {}).copy()
 merge_callbacks['svn:mergeinfo'] = mergeinfo_callback
+
+merge_callbacks = config.get('MERGE_CALLBACKS', {}).copy()
+# Whether to reflow first line in reflow_text
+REFLOW_FIRST_LINE = config.get('REFLOW_FIRST_LINE', True)
 
 gitrepo = open_or_init_repo(config["GIT_REPO"])
 svnclient = pysvn.Client()

--- a/agito.py
+++ b/agito.py
@@ -590,7 +590,7 @@ def reflow_text(path, entry, message):
 	lines = message.split("\n")
 
 	# reflow of first line may be not wanted
-	if not REFLOW_FIRST_LINE:
+	if not reflow_first_line:
 		result.append(lines.pop(0))
 
 	for line in lines:
@@ -1031,9 +1031,8 @@ assert ("GIT_REPO" in config), \
 merge_callbacks = config.get('MERGE_CALLBACKS', {}).copy()
 merge_callbacks['svn:mergeinfo'] = mergeinfo_callback
 
-merge_callbacks = config.get('MERGE_CALLBACKS', {}).copy()
 # Whether to reflow first line in reflow_text
-REFLOW_FIRST_LINE = config.get('REFLOW_FIRST_LINE', True)
+reflow_first_line = config.get('REFLOW_FIRST_LINE', True)
 
 gitrepo = open_or_init_repo(config["GIT_REPO"])
 svnclient = pysvn.Client()

--- a/example.cfg
+++ b/example.cfg
@@ -86,6 +86,9 @@ COMMIT_MESSAGE_FILTERS = [
 	agito.append_branch_info,  # Append SVN branch/rev info.
 ]
 
+# Configuration for agito.append_branch_info
+REFLOW_FIRST_LINE = True
+
 # List of revision numbers of Subversion revisions that should be
 # "filtered" from the converted history: any changes made in a filtered
 # revision will be included in the following revision instead. If you

--- a/example.cfg
+++ b/example.cfg
@@ -86,7 +86,10 @@ COMMIT_MESSAGE_FILTERS = [
 	agito.append_branch_info,  # Append SVN branch/rev info.
 ]
 
-# Configuration for agito.append_branch_info
+# Whether agito.reflow_text should attempt to reflow text on first line of
+# commit message.
+# Having this False would leave first line of commit message untouched but
+# still reflow rest of the lines.
 REFLOW_FIRST_LINE = True
 
 # List of revision numbers of Subversion revisions that should be


### PR DESCRIPTION
reflow method is nice, except if first line is cut, it changes behaviour. 

so i rather leave first line as is, but still reflow rest of the lines. the default behaviour is the current one.