### PR TITLE
allow mapping no user

### DIFF
--- a/agito.py
+++ b/agito.py
@@ -523,11 +523,11 @@ def username_to_author(username):
 	"""
 	authors = config.get("AUTHORS", {})
 	default_author = config.get("DEFAULT_AUTHOR", ("%", "%@localhost"))
+	username = username or "nobody"
 
 	if username in authors:
 		name, email = authors[username]
 	else:
-		username = username or "nobody"
 		name_pattern, email_pattern = default_author
 		name = name_pattern.replace('%', username)
 		email = email_pattern.replace('%', username)


### PR DESCRIPTION
the current [def username_to_author(username)](
https://github.com/fragglet/agito/blob/736745470dcf302023bb186a02e3a94d41b48c4a/agito.py#L527-L533)
puts always `nobody <nobody@example.com>` if author is `None`.

map `None` to 'nobody' so it could be mapped from `AUTHORS`