### PR TITLE
allow TZ in _DATE metadata fields

### DIFF
--- a/agito.py
+++ b/agito.py
@@ -645,6 +645,27 @@ def rewrite_commit_refs(path, entry, message):
 
 	return message
 
+def use_timezone(timezone):
+    """A git filter-branch filter that converts author and commit times to specifiedtimezone"""
+
+    # import locally, the pytz and dateutil Python modules are not required normally
+    import pytz
+    from dateutil.parser import parse
+
+    DATE_TIME_FORMAT_TZ = "%Y-%m-%d %H:%M:%S %z"
+    TZ = pytz.timezone(timezone)
+
+    def convert_localtime(timestr):
+        localtime = parse(timestr).astimezone(TZ)
+        return localtime.strftime(DATE_TIME_FORMAT_TZ)
+
+    def callback(path, entry, metadata, treedir):
+        # convert to local time
+        metadata['GIT_AUTHOR_DATE'] = convert_localtime(metadata['GIT_AUTHOR_DATE'])
+        metadata['GIT_COMMITTER_DATE'] = convert_localtime(metadata['GIT_COMMITTER_DATE'])
+
+    return callback
+
 def utc_time_string(seconds):
 	"""Convert epoch seconds to a time and timezone string"""
 	return time.strftime(DATE_TIME_FORMAT, time.gmtime(seconds)) + ' +0000'

--- a/example.cfg
+++ b/example.cfg
@@ -115,6 +115,7 @@ FILTER_REVISIONS = []
 
 FILTER_BRANCH_CALLBACKS = [
 #    my_filter_callback,
+#    agito.use_timezone('Europe/Tallinn'),   # rewrite GIT_AUTHOR_DATE and GIT_COMMITTER_DATE to specified timezone
 ]
 
 # Subversion properties used for tracking merges. This maps from a


### PR DESCRIPTION
simple implementation for #11

it currently just appends timezone info to `GIT_COMMITTER_DATE`, `GIT_AUTHOR_DATE` metadata values, so the change is not compatible if somebody modifies metadata date fields via `FILTER_BRANCH_CALLBACK`. however the conversion will abort with parse error, so it's not harmful.

if not using filter branch callback, no changes are visible, as `+0000` timezone is used.

ideally to be compatible with `git filter-branch` should support all three [Git date formats](https://github.com/git/git/blob/master/Documentation/date-formats.txt), but I haven't found good support in Python base libraries to do such parsing and Dulwich also doesn't have such methods.
