### PR TITLE
change FILTER_BRANCH_CALLBACK to list

### DIFF
--- a/agito.py
+++ b/agito.py
@@ -824,9 +824,8 @@ def construct_history(path, commit_id, log):
 
 		metadata = commit_metadata_from_entry(path, entry)
 
-		if "FILTER_BRANCH_CALLBACK" in config:
-			config["FILTER_BRANCH_CALLBACK"](path, entry,
-			                                 metadata, treedir)
+		for filter_branch in config.get('FILTER_BRANCH_CALLBACKS', []):
+			filter_branch(path, entry, metadata, treedir)
 
 		tree_id = treedir.save()
 

--- a/example.cfg
+++ b/example.cfg
@@ -112,8 +112,10 @@ FILTER_REVISIONS = []
 
 #def my_filter_callback(path, entry, metadata, treedir):
 #	pass
-#
-#FILTER_BRANCH_CALLBACK = my_filter_callback
+
+FILTER_BRANCH_CALLBACKS = [
+#    my_filter_callback,
+]
 
 # Subversion properties used for tracking merges. This maps from a
 # property name to a callback function to invoke when the property with


### PR DESCRIPTION
change single valued `FILTER_BRANCH_CALLBACK` to a list named `FILTER_BRANCH_CALLBACKS`, so could have multiple callbacks defined.

the end result would be that i could add sample timezone converter as filter provided by agito in #12
